### PR TITLE
install: remove outdated note on NixOS install

### DIFF
--- a/content/docs/install/5.linux-install-nix.md
+++ b/content/docs/install/5.linux-install-nix.md
@@ -6,13 +6,6 @@ fullpath: /docs
 order: 1.5
 ---
 
-<div class=warn>
-<ul>
-<li>This installation method is still in testing.</li>
-<li>The module and the package are only available in the nixos-unstable channel currently, but will be added in the 23.11 release.</li>
-</ul>
-</div>
-
 ## Installation
 
 Imperative installation:


### PR DESCRIPTION
23.11, including the audiobookshelf module, has been released & the previous release is EOL.