### PR TITLE
Update 2.docker-compose-install.md to include a time zone parameter

### DIFF
--- a/content/docs/install/2.docker-compose-install.md
+++ b/content/docs/install/2.docker-compose-install.md
@@ -18,6 +18,8 @@ services:
       - </path/to/podcasts>:/podcasts
       - </path/to/config>:/config
       - </path/to/metadata>:/metadata
+    environment:
+      - TZ=America/Toronto
 ```
 
 <div class=warn>
@@ -45,6 +47,7 @@ Still confused about Docker? Check out [this FAQ](/faq#im-still-confused-about-w
 >  -v </path/to/audiobooks>:/audiobooks \
 >  -v </path/to/podcasts>:/podcasts \
 >  --name audiobookshelf \
+>  -e TZ="America/Toronto" \
 >  ghcr.io/advplyr/audiobookshelf
 
 ``⚠️`` Windows users will need to remove the \ and run this as a single line


### PR DESCRIPTION
Updating the example docker script and command line to show how to change the time zone for the container so that the logs from Audiobookshelf match the admin's local time zone.