### PR TITLE
Docker FAQ and repository link updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Required:
 * [Node.js](https://nodejs.org/en) (version 20)
 
 ```
-git clone https://github.com/advplyr/audiobookshelf-web.git
+git clone https://github.com/audiobookshelf/audiobookshelf-web.git
 cd audiobookshelf-web
 ```
 

--- a/content/docs/0.introduction.md
+++ b/content/docs/0.introduction.md
@@ -12,4 +12,4 @@ Join our [Discord server](https://discord.gg/HQgCbd6E75) or [Matrix space](https
 
 If you are interested in integrating with Audiobookshelf, visit the [API documentation](https://api.audiobookshelf.org/). 
 
-The source for this documentation can be found at the [Audiobookshelf GitHub repository](https://github.com/advplyr/audiobookshelf-web/tree/master/content/docs/install). Contributions to this documentation can be provided through a pull request.
+The source for this documentation can be found at the [Audiobookshelf GitHub repository](https://github.com/audiobookshelf/audiobookshelf-web/tree/master/content/docs/install). Contributions to this documentation can be provided through a pull request.

--- a/content/docs/install/2.docker-compose-install.md
+++ b/content/docs/install/2.docker-compose-install.md
@@ -31,7 +31,7 @@ services:
 - `/config` will contain the database (users/books/libraries/settings). Beginning with `2.3.x`, [this needs to be on the same machine you are running ABS on](/guides/migration-and-backups#from-version-22x).
 - `/metadata` will contain cache, streams, covers, downloads, backups and logs
 - Map any other directories you want to use for your book and podcast collections (ebooks supported)
-Still confused about Docker? Check out [this FAQ](/faq/server/#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
+Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
 
 **``💡`` Prefer the CLI? This is our docker run command. YMMV**
 

--- a/content/docs/updating/1.docker-install.md
+++ b/content/docs/updating/1.docker-install.md
@@ -6,6 +6,6 @@ fullpath: /docs
 order: 2.1
 ---
 
-To upgrade the server to the newest version, you just need to pull the new docker image and restart the container.
+To upgrade the server to the newest version, you just need to pull the new docker image and restart the container. If you are using Portainer or Docker Desktop, you can just update the stack and pull the new image. If you are using a pinned version number, you will need to update that version number.
 
-Still confused about Docker? Check out [this FAQ](/faq#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
+Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)

--- a/content/docs/updating/2.docker-compose-install.md
+++ b/content/docs/updating/2.docker-compose-install.md
@@ -16,4 +16,4 @@ docker-compose down
 docker-compose up --detach
 ```
 
-Still confused about Docker? Check out [this FAQ](/faq/server/#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
+Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)

--- a/content/guides/0.index.md
+++ b/content/guides/0.index.md
@@ -8,5 +8,5 @@ fullpath: /guides
 
 Guides are user-contributed. Making a guide is a great way to support the community.
 
-You can contribute a guide by creating a markdown file like [these](https://github.com/advplyr/audiobookshelf-web/tree/master/content) in Github. If you aren't familiar with Github you can share that markdown file in our [Discord server](https://discord.gg/HQgCbd6E75) or [Matrix space](https://matrix.to/#/#audiobookshelf:matrix.org).
+You can contribute a guide by creating a markdown file like [these](https://github.com/audiobookshelf/audiobookshelf-web/tree/master/content) in Github. If you aren't familiar with Github you can share that markdown file in our [Discord server](https://discord.gg/HQgCbd6E75) or [Matrix space](https://matrix.to/#/#audiobookshelf:matrix.org).
 

--- a/content/guides/2.library_creation.md
+++ b/content/guides/2.library_creation.md
@@ -11,7 +11,7 @@ This guide will help you to create a library in ABS. This guide assumes you have
 
 NOTE: If you are using docker, make sure your mounts are set up correctly. If they are not set up correctly, you will lose data at some point in the future. The easiest way to check if they are set up correctly is to add a book to the library and ensure that it shows up in your file system. 
 
-Still confused about Docker? Check out [this FAQ](/faq#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
+Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
 
 # Setting up a library
 
@@ -24,7 +24,7 @@ To create a library in ABS:
 ![Add paths](/guides/library_setup/initial_library_creation.gif)
 * Modify library settings (you can set this up now or edit the settings later)
 ![Edit settings](/guides/library_setup/settings.jpg)
-* You can also set a schedule to rescan the library for new books or changes. This periodic scan is disabled by default. NOTE: This should not be necessary if the watcher is enabled and working because changes to your folders are detected and scanned automatically.
+* You can also set a schedule to rescan the library for new books or changes. This periodic scan is disabled by default. NOTE: This should not be necessary if the watcher is enabled and working because changes to your folders are detected and scanned automatically. The watcher is known to have issues with network mounted libraries and some filesystems.
 ![Periodic scan](/guides/library_setup/schedule_scan.jpg)
 * After creating the library, you can scan for items within the library using the "Scan" button or use the dropdown to scan. The library settings can be adjusted from here as well. Additional information on the scanner can be found [here](/guides/book-scanner).
 ![Periodic scan](/guides/library_setup/scan_and_dropdown.jpg)

--- a/content/guides/7.migration_and_backups.md
+++ b/content/guides/7.migration_and_backups.md
@@ -6,7 +6,7 @@ fullpath: /guides/migration-and-backups
 
 ---
 
-This page discusses common migration problems for server `2.2.x` through `2.4.x` and how to restore from backups.
+This page discusses common migration problems for server `2.2.x` through `2.8.x` and how to restore from backups.
 
 # Migration Instructions
 There are a lot of version numbers, so verify the version due to confusion with all of the 2's and 3's in version numbers.
@@ -56,5 +56,5 @@ To restore a backup in `2.2.x`, you can either use the web GUI in the server set
 
 These backups are just a zip file of the `/config`, `/metadata/authors` and `/metadata/items`. If you're on Windows, you can just rename the backup file to end in `.zip` instead of `.audiobookshelf`, then extract the backup. You will then replace the corresponding directories on your server with these extracted files. Note that the metadata directories from the backup are replacing the `/metadata/authors` and `/metadata/items` directories, NOT creating a new `/metadata-items` directory on the server.
 
-## Restoring 2.3.x and 2.4.x
+## Restoring 2.3.x and above
 If you are on a version with the SQLite database, you can follow the same directions as for `2.2.x`, except you will only have the `metadata-items` directory to replace, and move the `absdatabase.sqlite` to the `/config` folder if restoring using the file system.

--- a/content/guides/8.book_scanner.md
+++ b/content/guides/8.book_scanner.md
@@ -8,6 +8,8 @@ fullpath: /guides/book-scanner
 
 This guide describes how the book scanner works as of server `v2.5.0`.
 
+Book grouping is different from metadata parsing, with books being defined by directory due to how the data is stored in the database. The metadata parsing is how metadata is applied to the book, and does not take priority over the book grouping. This scanning occurs locally with no automatic lookups with online metadata providers. To get metadata from an online provider, you will need to perform a Match operation on the media or library.
+
 ## Book library scanner steps
 ![Scanner flowchart](/guides/scanner/scanner_flowchart.png)
 1. Library is scanned and files are grouped into books.

--- a/content/guides/9.podcasts.md
+++ b/content/guides/9.podcasts.md
@@ -15,7 +15,7 @@ ABS is not designed as a passthrough from other services, so you first must down
 
 NOTE: If you are using docker, make sure your mounts are set up correctly. If they are not set up correctly, you will lose data at some point in the future. The easiest way to check if they are set up correctly is to add a podcast to the library and ensure that it shows up in your file system whereever you mounted your podcasts to. 
 
-Still confused about Docker? Check out [this FAQ](/faq#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
+Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
 
 # Adding a podcast
 There are two ways to add a podcast to your server:

--- a/pages/showcase.vue
+++ b/pages/showcase.vue
@@ -4,7 +4,7 @@
       <div>
         <span class="material-icons text-warning text-2xl">priority_high</span>
       </div>
-      <p class="pl-2 text-base md:text-lg">Consider sending screenshots of your audiobookshelf to <a href="mailto:advplyr@protonmail.com" class="text-blue-500 underline">advplyr@protonmail.com</a> (or <a href="https://github.com/advplyr/audiobookshelf-web" target="_blank" class="text-blue-500 underline">submit a PR</a>) so we can show it off!</p>
+      <p class="pl-2 text-base md:text-lg">Consider sending screenshots of your audiobookshelf to <a href="mailto:advplyr@protonmail.com" class="text-blue-500 underline">advplyr@protonmail.com</a> (or <a href="https://github.com/audiobookshelf/audiobookshelf-web" target="_blank" class="text-blue-500 underline">submit a PR</a>) so we can show it off!</p>
     </div>
 
     <div class="py-8">


### PR DESCRIPTION
This PR updates:
- The remaining Docker FAQ links to point to the correct link (instead of being the general FAQ page)
- Links to this repository after moving to the organization
- Version numbers when specifically called out to 2.8.0