### PR TITLE
Translation guide

### DIFF
--- a/content/faq/1.general.md
+++ b/content/faq/1.general.md
@@ -24,18 +24,16 @@ If your feature request does not exist, you can create a new Feature Request or 
 
 ## How do I help with translations?
 
-Contributing translations is a fantastic way to help make the project accessible to more people.
+Contributing translations is a fantastic way to help make the project accessible to more people. All of the translations are provided by the community.
 
-- You can assist with translations by editing strings in the corresponding language file. Look for any strings that haven't been translated yet and provide a translation. If you notice inaccuracies in existing translations, feel free to update them.
+- If you see a string that has not been translated or the existing translation is inaccuarte, you can edit strings in the corresponding language file.
 
-- If you're adding new strings, update the English `en-us.json` file with the new key and value. If you know the translation for other languages, you can update those files as well. Please keep the keys sorted in alphabetical order.
+- If you're adding new strings, you can update the English `en-us.json` file with the new key and value. If you know the translation for other languages, you can update those files as well. Please keep the keys sorted in alphabetical order and do not edit the other language files.
 
 - If you want to translate into a new language, simply copy the `en-us.json` file and start translating the strings into your desired language.
 
 Once you've finished your translation work, you can submit it for review. If you're comfortable with GitHub, you can open a pull request (PR) on the corresponding repository. If GitHub isn't your thing, you can share the JSON file on Discord for someone else to handle the submission.
 
-Strings for the web client are located in the `client/strings` directory of the [server repository](https://github.com/advplyr/audiobookshelf).
-
-Strings for the mobile apps can be found in the `strings` directory of the [app repository](https://github.com/advplyr/audiobookshelf-app)
+There are two sets of translations: one for the [web client](https://github.com/advplyr/audiobookshelf/tree/master/client/strings), and one for the [mobile apps](https://github.com/advplyr/audiobookshelf-app/tree/master/strings).
 
 If you have any questions or need clarification on any aspect of the translation process, don't hesitate to ask for help on Discord. Happy translating! 

--- a/content/faq/1.general.md
+++ b/content/faq/1.general.md
@@ -22,3 +22,20 @@ You can also express support for an existing feature request in Discord/Matrix.
 
 If your feature request does not exist, you can create a new Feature Request or talk about it on Discord/Matrix.
 
+## How do I help with translations?
+
+Contributing translations is a fantastic way to help make the project accessible to more people.
+
+- You can assist with translations by editing strings in the corresponding language file. Look for any strings that haven't been translated yet and provide a translation. If you notice inaccuracies in existing translations, feel free to update them.
+
+- If you're adding new strings, update the English `en-us.json` file with the new key and value. If you know the translation for other languages, you can update those files as well. Please keep the keys sorted in alphabetical order.
+
+- If you want to translate into a new language, simply copy the `en-us.json` file and start translating the strings into your desired language.
+
+Once you've finished your translation work, you can submit it for review. If you're comfortable with GitHub, you can open a pull request (PR) on the corresponding repository. If GitHub isn't your thing, you can share the JSON file on Discord for someone else to handle the submission.
+
+Strings for the web client are located in the `client/strings` directory of the [server repository](https://github.com/advplyr/audiobookshelf).
+
+Strings for the mobile apps can be found in the `strings` directory of the [app repository](https://github.com/advplyr/audiobookshelf-app)
+
+If you have any questions or need clarification on any aspect of the translation process, don't hesitate to ask for help on Discord. Happy translating! 

--- a/pages/support.vue
+++ b/pages/support.vue
@@ -30,6 +30,8 @@
 
     <p class="mb-2 pl-4">- Guides on how to run the server and mobile apps locally.</p>
 
+    <p class="mb-2 pl-4">- <a class="text-blue-500 underline" href=/faq#how-do-i-help-with-translations>Translations</a> of the web client and mobile apps.</p>
+
     <p class="mb-2 pl-4">- Any other ideas you have to help the community get familiar with audiobookshelf.</p>
 
     <p class="my-4">If you want to contribute reach out via github, discord or email.</p>


### PR DESCRIPTION
Fixes #47 

Adds a new translation FAQ now that the i18n workflows have been merged to both the server and app repository.