### PR TITLE
Remove deprecated version from docker-compose.yml

### DIFF
--- a/content/docs/install/2.docker-compose-install.md
+++ b/content/docs/install/2.docker-compose-install.md
@@ -7,7 +7,6 @@ order: 1.2
 ---
 
 ```bash
-version: "3.7"
 services:
   audiobookshelf:
     image: ghcr.io/advplyr/audiobookshelf:latest


### PR DESCRIPTION
I've noticed that new versions of Docker start complaining if `version` is still part of the `docker-compose.yml`. Turns out that it has been deprecated for a while:

> […] in Docker Compose 1.27+, Docker deprecated the version property and it’s mainly supported now for backwards compatibility […]