### PR TITLE
change docker-compose into docker compose

### DIFF
--- a/content/docs/updating/2.docker-compose-install.md
+++ b/content/docs/updating/2.docker-compose-install.md
@@ -11,9 +11,9 @@ If you used docker compose, you just need to make sure the tag is either the ver
 Then, you can just run the following commands.
 
 ```bash
-docker-compose pull
-docker-compose down
-docker-compose up --detach
+docker compose pull
+docker compose down
+docker compose up --detach
 ```
 
 Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)


### PR DESCRIPTION
As mentioned in [#2866](https://github.com/advplyr/audiobookshelf/issues/2886), docker-compose is EOL and should be replaced with docker compose.