### PR TITLE
Clarify Need for Podcasts Library in Podcast Setup Guide

### DIFF
--- a/content/guides/9.podcasts.md
+++ b/content/guides/9.podcasts.md
@@ -18,6 +18,12 @@ NOTE: If you are using docker, make sure your mounts are set up correctly. If th
 Still confused about Docker? Check out [this FAQ](/faq/server#im-still-confused-about-what-docker-and-containers-are-and-how-they-work)
 
 # Adding a podcast
+First, you need to [add a new library](https://www.audiobookshelf.org/guides/library_creation) with type "Podcasts". Sign in as an admin, then:
+1) Click on settings
+2) Click on Libraries on the left
+3) Click the "Add Library" button
+4) Under Nedia Type, choose "Podcasts" 
+
 There are two ways to add a podcast to your server:
 1) Add the podcast through the UI.
 2) Add the episode files to your filesystem.


### PR DESCRIPTION
The current guide on adding podcasts doesn’t explicitly mention that creating a "Podcasts" library is a prerequisite for the feature to function. As a long-time user of Audiobookshelf (over a year or two), I wasn’t aware of this requirement, and it wasn’t immediately obvious during setup.

I ended up spending around 30 minutes troubleshooting and revisiting the documentation, before finally finding clarification in a Discord post.

Including this detail in the guide will help users avoid confusion and streamline the podcast setup process.