### PR TITLE
Update nginx reverse proxy config on nixos

### DIFF
--- a/content/docs/install/5.linux-install-nix.md
+++ b/content/docs/install/5.linux-install-nix.md
@@ -57,6 +57,7 @@ services.nginx = {
   virtualHosts."your.hostname.org" = {
     locations."/" = {
       proxyPass = "http://localhost:8234/";
+      proxyWebsockets = true;
     };
   };
 };


### PR DESCRIPTION
Without proxying websockets the application shows "Socket failed to connect" in the UI.
Adding the line `proxyWebsockets = true;` to the nginx configuration should fix that.
