### PR TITLE
Added information about podcast DISABLE_SSRF_REQUEST_FILTER.

### DIFF
--- a/content/guides/9.podcasts.md
+++ b/content/guides/9.podcasts.md
@@ -28,6 +28,11 @@ There are two ways to add a podcast to your server:
 1) Add the podcast through the UI.
 2) Add the episode files to your filesystem.
 
+NOTE: By default, ABS will not allow you to add a podcast that is hosted via a local IP address.
+This is a mitigation to potential server-side request forgery attacks (SSRF).
+In rare cases where you are self-hosting a podcast, you might need to disable this filter to add it.
+To do so, set the environment variable `DISABLE_SSRF_REQUEST_FILTER=1` on the ABS server.
+
 ### Adding through the UI
 You can add podcasts in the UI using the "Add" tab (either in the web interface or the app).
 You can search by name, RSS link, or upload an OPML file.


### PR DESCRIPTION
For those rare beasts self-hosting podcasts, it is critical to know that ABS will not add them unless the SSRF filter is disabled (since the UI and logs don't provide information about this).

I am hopeful that including the word "attack" will be enough to stop people turning this off unecessarily, but we could add another sentence admonishing them not to do so.