### PR TITLE
Testflight FAQ update

### DIFF
--- a/content/faq/3.app.md
+++ b/content/faq/3.app.md
@@ -55,8 +55,8 @@ Note that the exact release and clear time may vary by a few days depending on h
 ## How do I get an invite to Testflight?
 
 If the Testflight is not full (see 90 days after release table), you can attempt to join the Testflight.
-To do this, [follow the instructions found on the official Testflight site](https://testflight.apple.com/).
-The public registration link embedded in the "Download on the app store" image located at the top of this page and on the main page of the Audiobookshelf website.
+To do this, [follow the instructions found on the official Testflight site](https://testflight.apple.com/join/wiic7QIW).
+This link is the same one embedded in the "Download on the app store" image located on this website.
 If you click on the link and see "This beta is full", you will need to wait until the next time spots are cleared.
 
 ## Will I lose access when the Testflight build expires or a new build is published?

--- a/content/faq/3.app.md
+++ b/content/faq/3.app.md
@@ -56,7 +56,7 @@ Note that the exact release and clear time may vary by a few days depending on h
 
 If the Testflight is not full (see 90 days after release table), you can attempt to join the Testflight.
 To do this, [follow the instructions found on the official Testflight site](https://testflight.apple.com/).
-The public registration link embedded in the "Download on the app store" image located on this website.
+The public registration link embedded in the "Download on the app store" image located at the top of this page and on the main page of the Audiobookshelf website.
 If you click on the link and see "This beta is full", you will need to wait until the next time spots are cleared.
 
 ## Will I lose access when the Testflight build expires or a new build is published?

--- a/content/faq/3.app.md
+++ b/content/faq/3.app.md
@@ -33,11 +33,6 @@ Android has more features than iOS, but all of these features are planned for iO
 A checklist tracking the main remaining bugs for the iOS app is located [here](https://github.com/advplyr/audiobookshelf-app/issues/541).
 _Please do not_ leave additional comments on this issue that are just requests to release the app, this has already been communicated in various GitHub and Discord discussions (see [General FAQ](/faq#i-have-a-feature-request-how-should-i-bring-this-up)).
 
-## Why is the iOS beta full?
-
-The iOS beta app is managed through TestFlight and is full.
-The beta has a hard limit set by Apple and cannot be increased by us (requests have already been made and denied).
-
 ## When will spots be cleared in Testflight to make room for new users?
 
 Due to changes on Apple's side, we can no longer clear spots early from users who are not keeping the app up to date.


### PR DESCRIPTION
Update the FAQ link to include the invite code because people usually can't find it embedded in the "Get on App Store" link. Also temporarily removed "testflight is full"