### PR TITLE
Update: environment variables

### DIFF
--- a/content/docs/configuration/1.configuration.md
+++ b/content/docs/configuration/1.configuration.md
@@ -22,7 +22,7 @@ Here is a list of all available options:
   - It will contain cache, streams, covers, downloads, backups and logs.
 - `BACKUP_PATH` (default: `./metadata/backups`)
   - Path to where backups are stored.
-  - Backups contain a backup of the database in `/config` and images stored in `./metadata/items` and `./metadata/authors`
+  - Backups contain a backup of the database in `/config` and images/metadata stored in `./metadata/items` and `./metadata/authors`
 
 ## External Tools
 

--- a/content/docs/configuration/1.configuration.md
+++ b/content/docs/configuration/1.configuration.md
@@ -16,10 +16,13 @@ Here is a list of all available options:
 
 - `CONFIG_PATH` (default: `./config`)
   - Path to the config directory.
-  - It will contain the database (users/books/libraries/settings).
+  - It will contain the database (users/books/libraries/settings). This location must not be mounted over the network.
 - `METADATA_PATH` (default: `./metadata`)
   - Path to the metadata directory.
   - It will contain cache, streams, covers, downloads, backups and logs.
+- `BACKUP_PATH` (default: `./metadata/backups`)
+  - Path to where backups are stored.
+  - Backups contain a backup of the database in `/config` and images stored in `./metadata/items` and `./metadata/authors`
 
 ## External Tools
 
@@ -28,9 +31,6 @@ Here is a list of all available options:
   - If no path is set, Audiobookshelf will assume the binary to exist in the system path.
 - `FFPROBE_PATH` (default: `ffprobe`)
   - Path to the `ffprobe` binary.
-  - If no path is set, Audiobookshelf will assume the binary to exist in the system path.
-- `TONE_PATH` (default: `tone`)
-  - Path to the `tone` binary.
   - If no path is set, Audiobookshelf will assume the binary to exist in the system path.
 
 ## Network
@@ -48,9 +48,20 @@ Here is a list of all available options:
   - Secret used for generating the JSON Web Tokens.
   - If none is provided, a secure random token is generated automatically.
     That will usually be sufficient.
+- `ALLOW_CORS` (default: `'0'`)
+  - Allow Cross-Origin Resource Sharing if set to `'1'`.
+- `DISABLE_SSRF_REQUEST_FILTER` (default: `'0'`)
+  - Disables the security of using the "Server Side Request Filter".
+  - If you are self-hosting a podcast from the same server, you may need to disable the SSRF filter.
 
 ## Other
 
 - `SOURCE`
   - Installation source. Will be shown in the web client.
   - Usually set to `docker`, `debian` or `rpm`.
+- `NODE_ENV` (default: `production`)
+  - Type of deployment.
+  - Should be `production` unless using `development`.
+- `QUERY_LOGGING`
+  - Debug information for logging SQL queries
+  - Use `log` to log the queries, and `benchmark` to also log the runtime of each query.


### PR DESCRIPTION
This PR updates the environment variables for the server version `2.17.3`. I did not include the `SkipBinariesCheck` because it is not being used anywhere, or `serverUrl` because I was not sure if this is still being used or being updated as part of the subdirectory work.