### PR TITLE
Added Big Finish as metadata provider

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -29,8 +29,9 @@ The request and response format that ABS expects for the API is defined in [this
 These custom metadata providers have been made by the community and are not maintained as part of the core project.
 If you have made a custom provider and want to share, you can [open a PR for this file](https://github.com/audiobookshelf/audiobookshelf-web/blob/master/content/guides/13.custom-metadata-providers.md) to add your information to the table.
 
-| Provider  | Repository                                 | Public API | Notes                                  |
-| --------- | ------------------------------------------ | ---------- | -------------------------------------- |
-| abs-tract | https://github.com/ahobsonsayers/abs-tract | N/A        | Provides Goodreads and Kindle metadata |
-| lubimyczytac-abs | https://github.com/lakafior/lubimyczytac-abs | N/A        | Provides Lubimyczytac (biggest polish site about books) metadata |
-| audioteka-abs | https://github.com/lakafior/audioteka-abs | N/A        | Provides Audioteka (biggest polish site with audiobooks) metadata |
+| Provider         | Repository                                   | Public API                                | Auth | Notes                                                             |
+|------------------|----------------------------------------------|-------------------------------------------|------|-------------------------------------------------------------------|
+| abs-tract        | https://github.com/ahobsonsayers/abs-tract   | N/A                                       | N/A  | Provides Goodreads and Kindle metadata                            |
+| lubimyczytac-abs | https://github.com/lakafior/lubimyczytac-abs | N/A                                       | N/A  | Provides Lubimyczytac (biggest polish site about books) metadata  |
+| audioteka-abs    | https://github.com/lakafior/audioteka-abs    | N/A                                       | N/A  | Provides Audioteka (biggest polish site with audiobooks) metadata |
+| abs-bigfinish    | https://github.com/vito0912/abs-bigfinish    | https://audiobooks.dev/provider/bigfinish | abs  | Provides Big Finish metadata                                      |


### PR DESCRIPTION
Added Big Finish and formatted the table.
Added `Auth` column to the table.

# Big Finish Metadata Provider Integration

The Big Finish metadata provider is now available as an unofficial metadata provider.

Access it at `https://audiobooks.dev/provider/bigfinish` using the Authorization value `abs`.

This provider runs on the same server and domain as the Audiobookshelf Demo server.

The following metadata providers are also available but not included in the provider list. The below list services are not hosted by the devs itself. Each requires the Authorization value "abs". For optimal performance, I recommend hosting your own instances. Please note that these instances may change, become unavailable, or be removed. They are not hosted by the corresponding devs so do not create any issues if they are not working.

## Additional Metadata Providers

### Goodreads
- Source: [GitHub Repository](https://github.com/ahobsonsayers/abs-tract)
- Endpoint: `https://audiobooks.dev/provider/goodreads`

### Kindle
- Source: [GitHub Repository](https://github.com/ahobsonsayers/abs-tract)
- Endpoint: `https://audiobooks.dev/provider/kindle/<region>`
- Supported Regions: au, ca, de, es, fr, in, it, jp, uk, us

### Audioteka
- Source: [GitHub Repository](https://github.com/lakafior/audioteka-abs)
- Endpoint: `https://audiobooks.dev/provider/audioteka/pl`
- Note: This provider may be removed or updated due to limited regional support despite multiple regions being available.

### Lubimyczytac
- Source: [GitHub Repository](https://github.com/lakafior/lubimyczytac-abs)
- Endpoint: `https://audiobooks.dev/provider/lubimyczytac`

### Big Finish
- Source: [GitHub Repository](https://github.com/Vito0912/abs-bigfinish)
- Endpoint: `https://audiobooks.dev/provider/bigfinish`


---

All company names mentioned are trademarks of their respective owners. The server and I are not affiliated with any of these companies.