### PR TITLE
Add abs-storytel-provider to community providers list

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -35,3 +35,4 @@ If you have made a custom provider and want to share, you can [open a PR for thi
 | lubimyczytac-abs | https://github.com/lakafior/lubimyczytac-abs | N/A                                       | N/A  | Provides Lubimyczytac (biggest polish site about books) metadata  |
 | audioteka-abs    | https://github.com/lakafior/audioteka-abs    | N/A                                       | N/A  | Provides Audioteka (supports Polish and Czech language) metadata |
 | abs-bigfinish    | https://github.com/vito0912/abs-bigfinish    | https://audiobooks.dev/provider/bigfinish | abs  | Provides Big Finish metadata                                      |
+| abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | N/A                                 | abs  | Provides Storytel metadata                                        |


### PR DESCRIPTION
This pull request adds the abs-storytel-provider to the list of community providers in custom-metadata-providers.md.

Changes:

Added a new row for abs-storytel-provider in the community providers table.