### PR TITLE
Add OPDS community metadata provider

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -37,6 +37,7 @@ If you have made a custom provider and want to share, you can [open a PR for thi
 | abs-bigfinish    | https://github.com/vito0912/abs-bigfinish          | Provides Big Finish metadata                                     |
 | abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | Provides Storytel metadata                                       |
 | abs-hardcover    | https://github.com/Vito0912/hardcover-provider     | Provides Hardcover metadata                                      |
+| abs-opds         | https://github.com/DeXP/abs-opds                   | Any OPDS books catalog (biggest russian: Flibusta, inxp-web)     |
 
 ## Community hosted providers
 


### PR DESCRIPTION
Hello,

[OPDS](https://opds.io/) is often used for a e-book catalogs. It is a standart and language-agnostic. I believe, it's might be a good fallback for a lot of users.