### PR TITLE
added abs-meta

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -29,14 +29,15 @@ Issues with these providers should be brought up to the provider author and not 
 
 If you have made a custom provider and want to share, you can [open a PR for this file](https://github.com/audiobookshelf/audiobookshelf-web/blob/master/content/guides/13.custom-metadata-providers.md) to add your information to the table.
 
-| Provider         | Repository                                         | Notes                                                            |
-|------------------|----------------------------------------------------|------------------------------------------------------------------|
-| abs-tract        | https://github.com/ahobsonsayers/abs-tract         | Provides Goodreads and Kindle metadata                           |
-| lubimyczytac-abs | https://github.com/lakafior/lubimyczytac-abs       | Provides Lubimyczytac (biggest polish site about books) metadata |
-| audioteka-abs    | https://github.com/lakafior/audioteka-abs          | Provides Audioteka (supports Polish and Czech language) metadata |
-| abs-bigfinish    | https://github.com/vito0912/abs-bigfinish          | Provides Big Finish metadata                                     |
-| abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | Provides Storytel metadata                                       |
-| abs-hardcover    | https://github.com/Vito0912/hardcover-provider     | Provides Hardcover metadata                                      |
+| Provider         | Repository                                         | Notes                                                                |
+|------------------|----------------------------------------------------|----------------------------------------------------------------------|
+| abs-tract        | https://github.com/ahobsonsayers/abs-tract         | Provides Goodreads and Kindle metadata                               |
+| lubimyczytac-abs | https://github.com/lakafior/lubimyczytac-abs       | Provides Lubimyczytac (biggest polish site about books) metadata     |
+| audioteka-abs    | https://github.com/lakafior/audioteka-abs          | Provides Audioteka (supports Polish and Czech language) metadata     |
+| abs-bigfinish    | https://github.com/Vito0912/abs-bigfinish          | Provides Big Finish metadata                                         |
+| abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | Provides Storytel metadata                                           |
+| abs-hardcover    | https://github.com/Vito0912/hardcover-provider     | Provides Hardcover metadata                                          |
+| abs-meta         | https://github.com/Vito0912/abs-meta               | A metadata framework with caching for Storytel and BookBeat metadata |
 
 ## Community hosted providers
 


### PR DESCRIPTION
A metadata framework with caching for Storytel and BookBeat metadata