### PR TITLE
Add another Big Finish metadata provider

### DIFF
--- a/content/guides/13.custom-metadata-providers.md
+++ b/content/guides/13.custom-metadata-providers.md
@@ -35,6 +35,7 @@ If you have made a custom provider and want to share, you can [open a PR for thi
 | lubimyczytac-abs | https://github.com/lakafior/lubimyczytac-abs       | Provides Lubimyczytac (biggest polish site about books) metadata |
 | audioteka-abs    | https://github.com/lakafior/audioteka-abs          | Provides Audioteka (supports Polish and Czech language) metadata |
 | abs-bigfinish    | https://github.com/vito0912/abs-bigfinish          | Provides Big Finish metadata                                     |
+| bfpsearch-abs    | https://github.com/chooban/bfpsearch-abs           | Alternative Big Finish metadata provider                         |
 | abs-storytel     | https://github.com/Revisor01/abs-storytel-provider | Provides Storytel metadata                                       |
 | abs-hardcover    | https://github.com/Vito0912/hardcover-provider     | Provides Hardcover metadata                                      |
 


### PR DESCRIPTION
The existing provider in the list didn't work for me, so I forked another one, and updated it to give series data as well.